### PR TITLE
Update Constants.java

### DIFF
--- a/android/todo-full-sync/app/src/main/java/io/realm/todo/Constants.java
+++ b/android/todo-full-sync/app/src/main/java/io/realm/todo/Constants.java
@@ -28,6 +28,6 @@ public final class Constants {
      * (remember to use 'http/realm' instead of 'https/realms' if you didn't setup SSL on ROS yet)
      */
     private static final String INSTANCE_ADDRESS = "<REPLACE_WITH_INSTANCE>";
-    public static final String AUTH_URL = "http://" + INSTANCE_ADDRESS + "/auth";
-    public static final String REALM_URL = "realm://" + INSTANCE_ADDRESS;
+    public static final String AUTH_URL = "https://" + INSTANCE_ADDRESS + "/auth";
+    public static final String REALM_URL = "realms://" + INSTANCE_ADDRESS;
 }


### PR DESCRIPTION
Went through the tutorial and compiling failed because by default (as per documentation) the cloud uses https/realms. 
Since our documentation assumes Realm Cloud for a first user, we should use https/realms (e.g. SSL secure) channel by default.