### PR TITLE
Fix creating new Realms

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -1,5 +1,5 @@
 .idea
 .gradle
 build
-*.iml
+.idea/
 local.properties


### PR DESCRIPTION
Closing the Realm too soon meant that getting the access token was interrupted causing the server side Realm to never be created. Now we make sure any local changes are uploaded before closing the Realm.