### PR TITLE
Creates the Realm in the user's space

### DIFF
--- a/ios/02-full-sync/ToDo/Constants.swift
+++ b/ios/02-full-sync/ToDo/Constants.swift
@@ -13,6 +13,6 @@ struct Constants {
     static let MY_INSTANCE_ADDRESS = "MY_INSTANCE_ADDRESS" // <- update this
     
     static let AUTH_URL  = URL(string: "https://\(MY_INSTANCE_ADDRESS)")!
-    static let REALM_URL = URL(string: "realms://\(MY_INSTANCE_ADDRESS)/ToDo")!
+    static let REALM_URL = URL(string: "realms://\(MY_INSTANCE_ADDRESS)/~/ToDo")!
 }
 


### PR DESCRIPTION
With the existing code, the app attempts to create a Realm `/ToDo` but they don't have permission to do that. Even if they did, that would mean that all users shared the same list of todo items. The app should instead create the Real under the user's folder