### PR TITLE
Fixing the iOS full-sync example

### DIFF
--- a/ios/02-full-sync/Podfile.lock
+++ b/ios/02-full-sync/Podfile.lock
@@ -9,7 +9,7 @@ DEPENDENCIES:
   - RealmSwift
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Realm
     - RealmSwift
 
@@ -19,4 +19,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 56f3ee84c59355f9c12d37f90e54347be516d045
 
-COCOAPODS: 1.7.4
+COCOAPODS: 1.8.4

--- a/ios/02-full-sync/README.md
+++ b/ios/02-full-sync/README.md
@@ -1,6 +1,6 @@
 # Realm Cloud ToDo List - iOS
 
-This is a complement to the Realm Cloud _ToDo List_ tutorial https://docs.realm.io/cloud/ios-todo-app
+This is a complement to the Realm Cloud _ToDo List_ tutorial https://docs.realm.io/sync/getting-started-1/step-1-my-first-realm-app
 
 ## Requirements:
 

--- a/ios/02-full-sync/ToDo/Constants.swift
+++ b/ios/02-full-sync/ToDo/Constants.swift
@@ -13,6 +13,6 @@ struct Constants {
     static let MY_INSTANCE_ADDRESS = "MY_INSTANCE_ADDRESS" // <- update this
     
     static let AUTH_URL  = URL(string: "https://\(MY_INSTANCE_ADDRESS)")!
-    static let REALM_URL = URL(string: "realms://\(MY_INSTANCE_ADDRESS)/ToDo")!
+    static let REALM_URL = URL(string: "realms://\(MY_INSTANCE_ADDRESS)/~/ToDo")!
 }
 

--- a/ios/02-full-sync/ToDo/WelcomeViewController.swift
+++ b/ios/02-full-sync/ToDo/WelcomeViewController.swift
@@ -98,6 +98,19 @@ class WelcomeViewController: UIViewController {
         errorLabel.numberOfLines = 0
         errorLabel.textColor = .red
         container.addArrangedSubview(errorLabel)
+
+        if (SyncUser.all.count > 1) {
+            // If more than one user is unexpectedly logged in, log out all of them
+            for (_, user) in SyncUser.all {
+                user.logOut();
+            }
+        } else if (SyncUser.all.count == 1) {
+            // Switch to the items view, if a user is logged in
+            self.navigationController!.pushViewController(
+                ItemsViewController(),
+                animated: false
+            );
+        }
     }
 
     @objc func signIn() {


### PR DESCRIPTION
I propose that the path of the synced Realm become specific to the user (~/ToDo) instead of being a globally shared Realm. This PR also fixes issues happening if the user happens to get multiple users authenticated at the same time.

Before merging this I would also suggest changing the model such that `Item` has an `id` instead of an `itemId` field - the "item" is redundant in my opinion.